### PR TITLE
Fix Typo and Grammar Issues in Glossary File

### DIFF
--- a/CHAOSS Glossary.md
+++ b/CHAOSS Glossary.md
@@ -11,7 +11,7 @@ We understand the struggle in reading and understanding everything from a holist
 - FG: Focus Group 
 - SDG: Sustainable Development Goals 
 - WG: Working Group 
-- DEI: Diversity Equity Inclusion ex: DEI Badging
+- DEI: Diversity, Equity, and Inclusion e.g., DEI Badging
 - UN: United Nations 
 - FOSS|FLOSS: Free Open Source Software 
 - LFx: Linux Foundation
@@ -20,12 +20,12 @@ We understand the struggle in reading and understanding everything from a holist
 - MIT: Massachusetts Institute of Technology
 - CI/CD: Continuous Integration/Continuous Deployment
 - API: Application Programming Interface
-- MD.File: Markdown File. ex Contributor.md
+- MD.File: Markdown File e.g., Contributor.md
 - FOSDEM: Free and Open Source Software Developers' European Meeting
 - OSCA: Open Source Community Africa
 - Repo: Repository
-- *CON: Conference ex: CHAOSScon
+- *CON: Conference e.g., CHAOSScon
 - CHAOSScast: CHAOSS Podcast 
-- HacktoberFest: A month-long celebration of open-source projects, their maintainers, and the entire community of contributors usually done in October. 
+- Hacktoberfest: A month-long celebration of open-source projects, their maintainers, and the entire community of contributors usually done in October. 
 - Pycon: Python Conference 
  

--- a/CHAOSS Glossary.md
+++ b/CHAOSS Glossary.md
@@ -2,31 +2,30 @@
 The Dictionary to everything with an acronym here in [CHAOSS](https://chaoss.community/) 
 
 # The Glossary
-We understand the struggle in reading and understaning everything from a holitic point of view. Here are some of the Acronym you might come across as a contributor: 
+We understand the struggle in reading and understanding everything from a holistic point of view. Here are some of the Acronyms you might come across as a contributor: 
 
 - CHAOSS: Community Health Analytics in Open Source Software
-- MD: Mark Down 
+- MD: Markdown 
 - OSS: Open Source Software 
 - PR: Pull Request 
-- FG: Focus Group d
+- FG: Focus Group 
 - SDG: Sustainable Development Goals 
 - WG: Working Group 
 - DEI: Diversity Equity Inclusion ex: DEI Badging
 - UN: United Nations 
 - FOSS|FLOSS: Free Open Source Software 
-- LFx: Linus Foundation
+- LFx: Linux Foundation
 - OSI: Open Source Initiative 
 - OSOSS: Open Standards and Open Source Software
-- MIT; Massachusetts Institute of Technology
+- MIT: Massachusetts Institute of Technology
 - CI/CD: Continuous Integration/Continuous Deployment
 - API: Application Programming Interface
 - MD.File: Markdown File. ex Contributor.md
-- FOSSDEM: Free and Open source Software Developers' European
-- OSCAR: Open Source Community africa
+- FOSDEM: Free and Open Source Software Developers' European Meeting
+- OSCA: Open Source Community Africa
 - Repo: Repository
 - *CON: Conference ex: CHAOSScon
 - CHAOSScast: CHAOSS Podcast 
 - HacktoberFest: A month-long celebration of open-source projects, their maintainers, and the entire community of contributors usually done in October. 
 - Pycon: Python Conference 
-- 
  

--- a/CHAOSS Glossary.md
+++ b/CHAOSS Glossary.md
@@ -21,7 +21,7 @@ We understand the struggle in reading and understanding everything from a holist
 - CI/CD: Continuous Integration/Continuous Deployment
 - API: Application Programming Interface
 - MD.File: Markdown File e.g., Contributor.md
-- FOSDEM: Free and Open Source Software Developers' European Meeting
+- FOSDEM: Free and Open source Software Developers' European Meeting
 - OSCA: Open Source Community Africa
 - Repo: Repository
 - *CON: Conference e.g., CHAOSScon


### PR DESCRIPTION
This PR addresses typo and grammar issues in the CHAOSS glossary file to improve readability and accuracy. Below are the key changes made:

1. Fixed spelling and grammatical errors:
   - "understaning" → "understanding"
   - "holitic" → "holistic"
   - "Linus Foundation" → "Linux Foundation"
   - "FOSSDEM" → "FOSDEM"
   - "africa" → "Africa"
   
2. Corrected punctuation and consistency:
   - "MIT;" → "MIT:"
   - Added commas where needed, e.g., in "Diversity, Equity, and Inclusion."
   - Replaced "ex" with "e.g." in example usage, e.g., "e.g., Contributor.md."
   
3. Corrected capitalization:
   - "HacktoberFest" → "Hacktoberfest"

Closes #53 